### PR TITLE
Implement first hop option

### DIFF
--- a/cmd/gotraceroute.go
+++ b/cmd/gotraceroute.go
@@ -26,6 +26,7 @@ func address(address [4]byte) string {
 
 func main() {
 	var m = flag.Int("m", traceroute.DEFAULT_MAX_HOPS, `Set the max time-to-live (max number of hops) used in outgoing probe packets (default is 64)`)
+	var f = flag.Int("f", traceroute.DEFAULT_FIRST_HOP, `Set the first used time-to-live, e.g. the first hop (default is 1)`)
 	var q = flag.Int("q", 1, `Set the number of probes per "ttl" to nqueries (default is one probe).`)
 
 	flag.Parse()
@@ -33,6 +34,7 @@ func main() {
 	options := traceroute.TracerouteOptions{}
 	options.SetRetries(*q - 1)
 	options.SetMaxHops(*m + 1)
+	options.SetFirstHop(*f)
 
 	ipAddr, err := net.ResolveIPAddr("ip", host)
 	if err != nil {

--- a/traceroute.go
+++ b/traceroute.go
@@ -12,6 +12,7 @@ import (
 
 const DEFAULT_PORT = 33434
 const DEFAULT_MAX_HOPS = 64
+const DEFAULT_FIRST_HOP = 1
 const DEFAULT_TIMEOUT_MS = 500
 const DEFAULT_RETRIES = 3
 const DEFAULT_PACKET_SIZE = 52
@@ -56,6 +57,7 @@ func destAddr(dest string) (destAddr [4]byte, err error) {
 type TracerouteOptions struct {
 	port       int
 	maxHops    int
+	firstHop   int
 	timeoutMs  int
 	retries    int
 	packetSize int
@@ -81,6 +83,17 @@ func (options *TracerouteOptions) MaxHops() int {
 
 func (options *TracerouteOptions) SetMaxHops(maxHops int) {
 	options.maxHops = maxHops
+}
+
+func (options *TracerouteOptions) FirstHop() int {
+	if options.firstHop == 0 {
+		options.firstHop = DEFAULT_FIRST_HOP
+	}
+	return options.firstHop
+}
+
+func (options *TracerouteOptions) SetFirstHop(firstHop int) {
+	options.firstHop = firstHop
 }
 
 func (options *TracerouteOptions) TimeoutMs() int {
@@ -175,7 +188,7 @@ func Traceroute(dest string, options *TracerouteOptions, c ...chan TracerouteHop
 	timeoutMs := (int64)(options.TimeoutMs())
 	tv := syscall.NsecToTimeval(1000 * 1000 * timeoutMs)
 
-	ttl := 1
+	ttl := options.FirstHop()
 	retry := 0
 	for {
 		//log.Println("TTL: ", ttl)


### PR DESCRIPTION
traceroute should offer the possibilty to set the first hop that should
be used. This is done by setting the ttl to a given value before
starting the loop.